### PR TITLE
Add BGPT MCP to Literature & Knowledge Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@
 ## 🧪 AI Tools for Research
 
 ### Literature & Knowledge Management
+- [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) - MCP server for searching scientific papers with structured experimental data from full-text studies (methods, results, sample sizes, quality scores). Free tier available
 - [Semantic Scholar](https://www.semanticscholar.org/) - AI-powered academic search (Allen AI)
 - [arXiv](https://arxiv.org/) - Open-access repository of electronic preprints and postprints
 - [OpenAlex](https://openalex.org/) - Open catalog of scholarly papers and authors


### PR DESCRIPTION
Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) to the Literature & Knowledge Management section.

BGPT is an MCP server that searches scientific papers and returns structured experimental data from full-text studies — not just titles and abstracts. Returns 25+ fields per paper including methods, quantitative results, sample sizes, quality scores, and conclusions. 

Unlike Semantic Scholar or OpenAlex which return metadata, BGPT returns data extracted from the actual paper content, making it ideal for evidence synthesis, systematic reviews, and finding experimental details.

- Free tier: 50 searches, no API key needed
- Website: https://bgpt.pro/mcp
- Listed in the Official MCP Registry