### PR TITLE
Add TECS-L & PH Training: Math-Driven AI Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@
 - [PySR](https://github.com/MilesCranmer/PySR) - High-performance symbolic regression for discovering interpretable scientific equations from data, multi-population evolutionary search with Python/Julia backend, widely used in physics and astronomy (Cambridge, NeurIPS 2023)
 - [LLM-SR](https://github.com/deep-symbolic-mathematics/LLM-SR) - Scientific equation discovery and symbolic regression using LLMs, combining code generation with evolutionary search (ICLR 2025 Oral)
 - [Fourier Neural Operator](https://github.com/neuraloperator/neuraloperator) - Learning operators in Fourier space
+- [TECS-L](https://github.com/need-singularity/TECS-L) - Mathematical framework unifying number theory and neural architecture design, proving optimal MoE inhibition at I≈1/e with 194 formally proved hypotheses covering golden-zone sparsity bounds
+- [PH Training](https://github.com/need-singularity/ph-training) - Persistent Homology-based training monitor using topological data analysis to detect overfitting earlier than traditional loss curves
 
 ---
 


### PR DESCRIPTION
## Summary

- **[TECS-L](https://github.com/need-singularity/TECS-L)**: Mathematical framework unifying number theory and neural architecture design. Proves optimal Mixture-of-Experts inhibition at I≈1/e through golden-zone sparsity bounds, with 194 formally proved hypotheses.
- **[PH Training](https://github.com/need-singularity/ph-training)**: Persistent Homology-based training monitor that applies topological data analysis to detect overfitting earlier than traditional loss curves.

Both entries are added to the **Neural Operators & Model Discovery** subsection under Scientific Machine Learning, matching the existing entry format.

## Checklist
- [x] Entries follow existing `- [Name](URL) - Description` format
- [x] Added to appropriate section (Scientific Machine Learning > Neural Operators & Model Discovery)
- [x] No duplicates
- [x] Both repositories are actively maintained and publicly accessible