### PR TITLE
Add QQA4CO under Physics & Astronomy → Machine Learning for Physics

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@
 - [Physics-Informed Neural Networks](https://github.com/maziarraissi/PINNs) - Physics-constrained ML
 - [EquiformerV2](https://github.com/atomicarchitects/equiformer_v2) - Improved equivariant Transformer for 3D atomic graphs (ICLR2024)
 - [Equiformer](https://github.com/atomicarchitects/equiformer) - Equivariant graph attention Transformer (ICLR2023)
+- [QQA4CO](https://github.com/Yuma-Ichikawa/QQA4CO) - PyTorch library for large-scale combinatorial / spin-glass optimisation via Parallel Quasi-Quantum Annealing (PQQA, ICLR 2025). Treats the energy landscape of QUBO / Ising / Edwards–Anderson / Sherrington–Kirkpatrick / Hopfield models with a quantum-inspired schedule, batched on GPU. Streamlit demo included.
 
 #### Astronomy & Astrophysics
 - [AstroPy](https://github.com/astropy/astropy) - Python astronomy tools


### PR DESCRIPTION
Adds **QQA4CO** under `Domain-Specific Applications → Physics & Astronomy → Machine Learning for Physics`.

QQA4CO is a PyTorch library that solves classical spin-glass / Ising / QUBO instances via **Parallel Quasi-Quantum Annealing (PQQA)** (Ichikawa & Arai, ICLR 2025). Its built-in problem catalogue covers physics-flavoured benchmarks — Edwards–Anderson, Sherrington–Kirkpatrick, Hopfield associative memory, binary perceptron — alongside MaxCut / MIS / Graph Colouring, so it sits naturally in this sub-section.

- Paper: https://openreview.net/forum?id=9EfBeXaXf0 (ICLR 2025, poster) · arXiv:[2409.02135](https://arxiv.org/abs/2409.02135)
- License: BSD-3-Clause-Clear · `pip install qqa` · DOI: [10.5281/zenodo.19648231](https://doi.org/10.5281/zenodo.19648231)

Bullet format matches the surrounding entries.