### PR TITLE
Add Skill Hub — 4133+ AI Agent Skills Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,6 +938,11 @@ We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.
 
 ---
 
+## 🔧 AI Agent Skills & Tools
+
+- [Skill Hub](https://github.com/rdone4425/skill) — 4133+ AI Agent Skills directory classified across 22 categories. Filter by platform (Claude Code, Codex, Cursor, Hermes, OpenCode). [Live site](https://skill.442595.xyz/)
+
+
 ## 📄 License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Added Skill Hub as a resource in the AI Agent Skills section.

Skill Hub is a categorized directory with 4133+ AI Agent Skills across 22 categories (dev tools, agent framework, design UI, data AI, security, etc.).

🔗 https://skill.442595.xyz/
📂 https://github.com/rdone4425/skill